### PR TITLE
Add compiler option to use C++17 on every platform

### DIFF
--- a/code/premake5.lua
+++ b/code/premake5.lua
@@ -22,7 +22,7 @@ workspace "PS4Delta"
     location "../build"
     os.mkdir"../build/symbols"
     characterset "Unicode"
-	buildoptions "/std:c++17"
+	cppdialect "C++17"
 
     -- multi threaded compilation
     flags "MultiProcessorCompile"


### PR DESCRIPTION
Refer to: https://github.com/premake/premake-core/wiki/cppdialect
It didn't let me reopen the old PR so I made a new one, hope that's OK.